### PR TITLE
Allow currency filtering

### DIFF
--- a/src/Http/StripeBalanceController.php
+++ b/src/Http/StripeBalanceController.php
@@ -9,6 +9,16 @@ class StripeBalanceController extends Controller
 {
     public function index()
     {
-        return response()->json(['balance' => (new StripeClient())->getBalance()]);
+        $balance = (new StripeClient)->getBalance();
+        $values = ['available', 'pending'];
+        $currency = config('nova.currency');
+
+        foreach ($values as $value) {
+            $balance->{$value} = collect($balance->{$value})->filter(function ($x) use($currency) {
+                return $x->__debugInfo()['currency'] === $currency;
+            })->toArray();
+        }
+
+        return response()->json(['balance' => $balance]);
     }
 }


### PR DESCRIPTION
It seems USD is always returned, even if it was never used and the available/pending amount is 0.00.

This allows non-americans to filter out the USD amounts.