### PR TITLE
Endpoint Tests for Balance and Transaction Detail

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      max-parallel: 1
       matrix:
         php: [7.3, 7.4, 8.0]
         laravel: [6.*, 7.*, 8.*]

--- a/tests/StripeChargeControllerTest.php
+++ b/tests/StripeChargeControllerTest.php
@@ -19,9 +19,9 @@ class StripeChargeControllerTest extends TestCase
         parent::setUp();
         $this->stripe = new StripeClient(Config::get('services.stripe.secret'));
 
-        $this->stripe->charges->all()->count()
-            ? $this->charge = $this->stripe->charges->all(['limit' => 1])->first()
-            : $this->charge = $this->stripe->charges->create([
+        $this->charge = $this->stripe->charges->all()->count()
+            ? $this->stripe->charges->all(['limit' => 1])->first()
+            : $this->stripe->charges->create([
                 'amount' => $this->faker->numberBetween(50, 1000),
                 'currency' => 'usd',
                 'source' => 'tok_mastercard',


### PR DESCRIPTION
Adds tests for remaining endpoints. 

Note: Concurrent matrix test runs could potentially cause errors in the `it_shows_the_current_balance` test, since the other runs could alter the balance between retrieving it from Stripe and hitting our endpoint. To prevent this issue, I added `max-parallel: 1` to the workflow. This slows down the entire run considerably, so I'm open to other solutions. 