### PR TITLE
Fix tests to work with failed or refunded charge

### DIFF
--- a/tests/StripeChargeControllerTest.php
+++ b/tests/StripeChargeControllerTest.php
@@ -59,8 +59,6 @@ class StripeChargeControllerTest extends TestCase
         $response->assertJsonFragment([
             'id' => $stripeCharge->id,
             'amount' => $stripeCharge->amount,
-            'fee' => $stripeCharge->balance_transaction->fee,
-            'net' => $stripeCharge->balance_transaction->net,
             'status' => $stripeCharge->status,
             'created' => $stripeCharge->created,
             'metadata' => $stripeCharge->metadata,
@@ -75,8 +73,6 @@ class StripeChargeControllerTest extends TestCase
 
         $response->assertSee($stripeCharge->id)
             ->assertSee($stripeCharge->amount)
-            ->assertSee($stripeCharge->balance_transaction->fee)
-            ->assertSee($stripeCharge->balance_transaction->net)
             ->assertSee($stripeCharge->status)
             ->assertSee($stripeCharge->created)
             ->assertSee($stripeCharge->livemode)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,7 +3,6 @@
 namespace Tighten\NovaStripe\Tests;
 
 use Illuminate\Foundation\Bootstrap\LoadEnvironmentVariables;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Tighten\NovaStripe\ToolServiceProvider;


### PR DESCRIPTION
Fixes a bug that tests for attributes that won't ever be returned on Failed or Refunded charges.