### PR TITLE
Charges List UI Updates

### DIFF
--- a/dist/js/tool.js
+++ b/dist/js/tool.js
@@ -2236,7 +2236,7 @@ exports = module.exports = __webpack_require__(1)(false);
 
 
 // module
-exports.push([module.i, "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n/* Scoped Styles */\n", ""]);
+exports.push([module.i, "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n/* Scoped Styles */\n", ""]);
 
 // exports
 
@@ -2250,11 +2250,6 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__ChargesPaginationLinks_vue__ = __webpack_require__(19);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__ChargesPaginationLinks_vue___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__ChargesPaginationLinks_vue__);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__utils_moneyFormat__ = __webpack_require__(3);
-//
-//
-//
-//
-//
 //
 //
 //
@@ -2673,39 +2668,8 @@ var render = function() {
                           _vm._v(
                             "\n                    " +
                               _vm._s(charge.id) +
-                              "\n                    "
-                          ),
-                          charge.refunded
-                            ? _c("span", { staticClass: "text-70" }, [
-                                _c("span", { staticClass: "hidden sr-only" }, [
-                                  _vm._v("Refunded")
-                                ]),
-                                _vm._v(" "),
-                                _c(
-                                  "svg",
-                                  {
-                                    staticClass: "h-5 w-5 ml-3",
-                                    attrs: {
-                                      xmlns: "http://www.w3.org/2000/svg",
-                                      fill: "none",
-                                      viewBox: "0 0 24 24",
-                                      stroke: "currentColor"
-                                    }
-                                  },
-                                  [
-                                    _c("path", {
-                                      attrs: {
-                                        "stroke-linecap": "round",
-                                        "stroke-linejoin": "round",
-                                        "stroke-width": "2",
-                                        d:
-                                          "M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z"
-                                      }
-                                    })
-                                  ]
-                                )
-                              ])
-                            : _vm._e()
+                              "\n                "
+                          )
                         ]),
                         _vm._v(" "),
                         _c("td", [
@@ -2721,15 +2685,24 @@ var render = function() {
                         ]),
                         _vm._v(" "),
                         _c("td", [
-                          _c(
-                            "span",
-                            {
-                              staticClass:
-                                "rounded-lg px-3 py-1 capitalize text-xs font-black",
-                              class: _vm.statusClass(charge.status)
-                            },
-                            [_vm._v(_vm._s(charge.status))]
-                          )
+                          !charge.refunded
+                            ? _c(
+                                "span",
+                                {
+                                  staticClass:
+                                    "rounded-lg px-3 py-1 capitalize text-xs font-black",
+                                  class: _vm.statusClass(charge.status)
+                                },
+                                [_vm._v(_vm._s(charge.status))]
+                              )
+                            : _c(
+                                "span",
+                                {
+                                  staticClass:
+                                    "rounded-lg px-3 py-1 capitalize text-xs font-black bg-40 text-80"
+                                },
+                                [_vm._v("Refunded")]
+                              )
                         ]),
                         _vm._v(" "),
                         _c("td", [

--- a/dist/js/tool.js
+++ b/dist/js/tool.js
@@ -2236,7 +2236,7 @@ exports = module.exports = __webpack_require__(1)(false);
 
 
 // module
-exports.push([module.i, "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n/* Scoped Styles */\n", ""]);
+exports.push([module.i, "\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n/* Scoped Styles */\n", ""]);
 
 // exports
 
@@ -2320,6 +2320,16 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 //
 //
 //
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
 
 
 
@@ -2328,21 +2338,28 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
     components: {
         'charges-pagination-links': __WEBPACK_IMPORTED_MODULE_0__ChargesPaginationLinks_vue___default.a
     },
-
     data: function data() {
         return {
             charges: {},
             initialLoading: true,
             loading: false,
             hasMore: false,
-            page: 1
+            page: 1,
+            statusClassList: {
+                'succeeded': 'bg-success-light text-success-dark',
+                'pending': 'bg-warning-light text-warning-dark',
+                'failed': 'bg-danger-light text-danger-dark'
+            }
         };
     },
 
-
+    computed: {
+        hasPrevious: function hasPrevious() {
+            return this.page > 1;
+        }
+    },
     methods: {
         moment: moment,
-
         listCharges: function listCharges(params) {
             var _this = this;
 
@@ -2368,15 +2385,11 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             if (this.hasPrevious) {
                 this.page--;
             }
+        },
+        statusClass: function statusClass(status) {
+            return this.statusClassList[status];
         }
     },
-
-    computed: {
-        hasPrevious: function hasPrevious() {
-            return this.page > 1;
-        }
-    },
-
     filters: {
         date: function date(_date) {
             return moment.unix(_date).format('YYYY/MM/DD h:mm:ss a');
@@ -2385,7 +2398,6 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 
         money: __WEBPACK_IMPORTED_MODULE_1__utils_moneyFormat__["a" /* default */]
     },
-
     created: function created() {
         this.listCharges();
     }
@@ -2657,7 +2669,44 @@ var render = function() {
                   _vm._l(_vm.charges, function(charge) {
                     return _c("tbody", [
                       _c("tr", [
-                        _c("td", [_vm._v(_vm._s(charge.id))]),
+                        _c("td", [
+                          _vm._v(
+                            "\n                    " +
+                              _vm._s(charge.id) +
+                              "\n                    "
+                          ),
+                          charge.refunded
+                            ? _c("span", { staticClass: "text-70" }, [
+                                _c("span", { staticClass: "hidden sr-only" }, [
+                                  _vm._v("Refunded")
+                                ]),
+                                _vm._v(" "),
+                                _c(
+                                  "svg",
+                                  {
+                                    staticClass: "h-5 w-5 ml-3",
+                                    attrs: {
+                                      xmlns: "http://www.w3.org/2000/svg",
+                                      fill: "none",
+                                      viewBox: "0 0 24 24",
+                                      stroke: "currentColor"
+                                    }
+                                  },
+                                  [
+                                    _c("path", {
+                                      attrs: {
+                                        "stroke-linecap": "round",
+                                        "stroke-linejoin": "round",
+                                        "stroke-width": "2",
+                                        d:
+                                          "M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z"
+                                      }
+                                    })
+                                  ]
+                                )
+                              ])
+                            : _vm._e()
+                        ]),
                         _vm._v(" "),
                         _c("td", [
                           _vm._v(
@@ -2671,7 +2720,17 @@ var render = function() {
                           _vm._v(_vm._s(_vm._f("date")(charge.created)))
                         ]),
                         _vm._v(" "),
-                        _c("td", [_vm._v(_vm._s(charge.status))]),
+                        _c("td", [
+                          _c(
+                            "span",
+                            {
+                              staticClass:
+                                "rounded-lg px-3 py-1 capitalize text-xs font-black",
+                              class: _vm.statusClass(charge.status)
+                            },
+                            [_vm._v(_vm._s(charge.status))]
+                          )
+                        ]),
                         _vm._v(" "),
                         _c("td", [
                           _c(

--- a/resources/js/components/ChargesTable.vue
+++ b/resources/js/components/ChargesTable.vue
@@ -38,16 +38,18 @@
                 <tr>
                     <td>
                         {{ charge.id }}
-                        <span v-if="charge.refunded" class="ml-3 text-70">
-                            <span class="sr-only">Refunded</span>
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <span v-if="charge.refunded" class="text-70">
+                            <span class="hidden sr-only">Refunded</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 ml-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z" />
                             </svg>
                         </span>
                     </td>
                     <td>{{ charge.currency | money(charge.amount) }}</td>
                     <td>{{ charge.created | date }}</td>
-                    <td>{{ charge.status }}</td>
+                    <td>
+                        <span class="rounded-lg px-3 py-1 capitalize text-xs font-black" :class="statusClass(charge.status)">{{ charge.status }}</span>
+                    </td>
                     <td>
                         <span>
                             <router-link
@@ -84,7 +86,6 @@ export default {
     components: {
         'charges-pagination-links': ChargesPaginationLinks
     },
-
     data() {
         return {
             charges: {},
@@ -92,12 +93,20 @@ export default {
             loading: false,
             hasMore: false,
             page: 1,
+            statusClassList: {
+                'succeeded' : 'bg-success-light text-success-dark',
+                'pending' : 'bg-warning-light text-warning-dark',
+                'failed' : 'bg-danger-light text-danger-dark',
+            }
         }
     },
-
+    computed: {
+        hasPrevious() {
+            return this.page > 1
+        }
+    },
     methods: {
         moment: moment,
-
         listCharges(params) {
             Nova.request().get('/nova-vendor/nova-stripe/stripe/charges', { params })
                 .then((response) => {
@@ -107,7 +116,6 @@ export default {
                     this.loading = false
                 })
         },
-
         nextPage() {
             this.loading = true
 
@@ -115,7 +123,6 @@ export default {
 
             this.page++
         },
-
         previousPage() {
             this.loading = true
 
@@ -124,15 +131,11 @@ export default {
             if (this.hasPrevious) {
                 this.page--
             }
-        }
+        },
+        statusClass(status) {
+            return this.statusClassList[status];
+        },
     },
-
-    computed: {
-        hasPrevious() {
-            return this.page > 1
-        }
-    },
-
     filters: {
         date(date) {
             return moment.unix(date).format('YYYY/MM/DD h:mm:ss a')
@@ -140,7 +143,6 @@ export default {
 
         money
     },
-
     created() {
         this.listCharges()
     },

--- a/resources/js/components/ChargesTable.vue
+++ b/resources/js/components/ChargesTable.vue
@@ -42,8 +42,7 @@
                     <td>{{ charge.currency | money(charge.amount) }}</td>
                     <td>{{ charge.created | date }}</td>
                     <td>
-                        <span v-if="! charge.refunded" class="rounded-lg px-3 py-1 capitalize text-xs font-black" :class="statusClass(charge.status)">{{ charge.status }}</span>
-                        <span v-else class="rounded-lg px-3 py-1 capitalize text-xs font-black bg-40 text-80">Refunded</span>
+                        <span class="rounded-lg px-3 py-1 capitalize text-xs font-black" :class="statusClass(charge.status)">{{ charge.refunded ? 'Refunded' : charge.status }}</span>
                     </td>
                     <td>
                         <span>

--- a/resources/js/components/ChargesTable.vue
+++ b/resources/js/components/ChargesTable.vue
@@ -38,17 +38,12 @@
                 <tr>
                     <td>
                         {{ charge.id }}
-                        <span v-if="charge.refunded" class="text-70">
-                            <span class="hidden sr-only">Refunded</span>
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 ml-3" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z" />
-                            </svg>
-                        </span>
                     </td>
                     <td>{{ charge.currency | money(charge.amount) }}</td>
                     <td>{{ charge.created | date }}</td>
                     <td>
-                        <span class="rounded-lg px-3 py-1 capitalize text-xs font-black" :class="statusClass(charge.status)">{{ charge.status }}</span>
+                        <span v-if="! charge.refunded" class="rounded-lg px-3 py-1 capitalize text-xs font-black" :class="statusClass(charge.status)">{{ charge.status }}</span>
+                        <span v-else class="rounded-lg px-3 py-1 capitalize text-xs font-black bg-40 text-80">Refunded</span>
                     </td>
                     <td>
                         <span>

--- a/resources/js/components/ChargesTable.vue
+++ b/resources/js/components/ChargesTable.vue
@@ -36,7 +36,15 @@
 
                 <tbody v-for="charge in charges">
                 <tr>
-                    <td>{{ charge.id }}</td>
+                    <td>
+                        {{ charge.id }}
+                        <span v-if="charge.refunded" class="ml-3 text-70">
+                            <span class="sr-only">Refunded</span>
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M16 15v-1a4 4 0 00-4-4H8m0 0l3 3m-3-3l3-3m9 14V5a2 2 0 00-2-2H6a2 2 0 00-2 2v16l4-2 4 2 4-2 4 2z" />
+                            </svg>
+                        </span>
+                    </td>
                     <td>{{ charge.currency | money(charge.amount) }}</td>
                     <td>{{ charge.created | date }}</td>
                     <td>{{ charge.status }}</td>


### PR DESCRIPTION
Makes status codes a little easier to understand at a glance, by adding colors for each status. Also adds `refunded` in the status column (even though it isn't strictly a `status`). Refunded transactions will always have a `status` with a value of `succeeded`, which seemed confusing to me. This approach made the most sense to me visually, but I'm totally open to feedback.

<img width="1254" alt="Screen Shot 2021-07-19 at 5 02 05 PM" src="https://user-images.githubusercontent.com/4378273/126227342-92c1949a-1736-4552-8fc6-c198c61f940b.png">
