### PR TITLE
Add Refund from Charge Detail Page

### DIFF
--- a/dist/js/tool.js
+++ b/dist/js/tool.js
@@ -2846,6 +2846,9 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 //
 //
 //
+//
+//
+//
 
 
 
@@ -2863,12 +2866,15 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 
     methods: {
         refund: function refund(chargeId) {
-            this.deleting = !this.deleting;
+            var _this = this;
 
-            // axios call here
+            this.deleting = true;
 
+            Nova.request().post('/nova-vendor/nova-stripe/stripe/charges/' + this.chargeId + '/refund').then(function (response) {
+                _this.$refs.detail.getCharge();
+            });
 
-            this.deleting = !this.deleting;
+            this.deleting = false;
         }
     }
 });
@@ -3116,12 +3122,13 @@ var render = function() {
                   }
                 }
               },
-              [_vm._v("Refund")]
+              [_vm._v("\n            Refund\n        ")]
             )
           : _vm._e()
       ]),
       _vm._v(" "),
       _c("charge-detail-card", {
+        ref: "detail",
         attrs: { "charge-id": _vm.chargeId },
         on: {
           "charge-loaded": function($event) {

--- a/dist/js/tool.js
+++ b/dist/js/tool.js
@@ -2871,6 +2871,7 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             this.deleting = true;
 
             Nova.request().post('/nova-vendor/nova-stripe/stripe/charges/' + this.chargeId + '/refund').then(function (response) {
+                Nova.success('Charge Successfully Refunded!');
                 _this.$refs.detail.getCharge();
             });
 

--- a/dist/js/tool.js
+++ b/dist/js/tool.js
@@ -2834,14 +2834,42 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 //
 //
 //
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
+//
 
 
 
 /* harmony default export */ __webpack_exports__["default"] = ({
     props: ['chargeId'],
-
     components: {
         'charge-detail-card': __WEBPACK_IMPORTED_MODULE_0__components_ChargeDetailCard_vue___default.a
+    },
+    data: function data() {
+        return {
+            charge: undefined,
+            deleting: false
+        };
+    },
+
+    methods: {
+        refund: function refund(chargeId) {
+            this.deleting = !this.deleting;
+
+            // axios call here
+
+
+            this.deleting = !this.deleting;
+        }
     }
 });
 
@@ -2964,6 +2992,7 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             Nova.request().get('/nova-vendor/nova-stripe/stripe/charges/' + this.chargeId).then(function (response) {
                 _this.charge = response.data.charge;
                 _this.initialLoading = false;
+                _this.$emit('charge-loaded', response.data.charge);
             });
         },
         formatMoney: function formatMoney(amount, currency) {
@@ -3074,7 +3103,32 @@ var render = function() {
     [
       _c("heading", { staticClass: "mb-6" }, [_vm._v("Charge Details")]),
       _vm._v(" "),
-      _c("charge-detail-card", { attrs: { "charge-id": _vm.chargeId } })
+      _c("div", { staticClass: "flex flex-row-reverse mb-3" }, [
+        _vm.charge && !_vm.charge.refunded
+          ? _c(
+              "button",
+              {
+                staticClass: "btn-primary px-4 py-2 rounded",
+                attrs: { disabled: _vm.deleting },
+                on: {
+                  click: function($event) {
+                    return _vm.refund(_vm.charge.id)
+                  }
+                }
+              },
+              [_vm._v("Refund")]
+            )
+          : _vm._e()
+      ]),
+      _vm._v(" "),
+      _c("charge-detail-card", {
+        attrs: { "charge-id": _vm.chargeId },
+        on: {
+          "charge-loaded": function($event) {
+            _vm.charge = $event
+          }
+        }
+      })
     ],
     1
   )

--- a/package.json
+++ b/package.json
@@ -16,5 +16,11 @@
     "dependencies": {
         "currency.js": "^1.2.1",
         "vue": "^2.5.0"
+    },
+    "prettier": {
+        "singleQuote": true,
+        "trailingComma": "es5",
+        "tabWidth": 4,
+        "printWidth": 80
     }
 }

--- a/resources/js/components/ChargeDetailCard.vue
+++ b/resources/js/components/ChargeDetailCard.vue
@@ -65,6 +65,7 @@ export default {
                 .then((response) => {
                     this.charge = response.data.charge
                     this.initialLoading = false
+                    this.$emit('charge-loaded', response.data.charge);
                 })
         },
 

--- a/resources/js/views/Detail.vue
+++ b/resources/js/views/Detail.vue
@@ -8,10 +8,13 @@
                 class="btn-primary px-4 py-2 rounded"
                 @click="refund(charge.id)"
                 :disabled="deleting"
-            >Refund</button>
+            >
+                Refund
+            </button>
         </div>
 
         <charge-detail-card
+            ref="detail"
             :charge-id="chargeId"
             @charge-loaded="charge = $event"
         />
@@ -19,28 +22,35 @@
 </template>
 
 <script>
-    import ChargeDetailCard from '../components/ChargeDetailCard.vue'
+import ChargeDetailCard from '../components/ChargeDetailCard.vue';
 
-    export default {
-        props: ['chargeId'],
-        components: {
-            'charge-detail-card': ChargeDetailCard,
+export default {
+    props: ['chargeId'],
+    components: {
+        'charge-detail-card': ChargeDetailCard,
+    },
+    data() {
+        return {
+            charge: undefined,
+            deleting: false,
+        };
+    },
+    methods: {
+        refund(chargeId) {
+            this.deleting = true;
+
+            Nova.request()
+                .post(
+                    '/nova-vendor/nova-stripe/stripe/charges/' +
+                        this.chargeId +
+                        '/refund'
+                )
+                .then((response) => {
+                    this.$refs.detail.getCharge();
+                });
+
+            this.deleting = false;
         },
-        data() {
-            return {
-                charge: undefined,
-                deleting: false,
-            }
-        },
-        methods: {
-            refund(chargeId) {
-                this.deleting = !this.deleting;
-
-                // axios call here
-
-
-                this.deleting = !this.deleting;
-            },
-        },
-    }
+    },
+};
 </script>

--- a/resources/js/views/Detail.vue
+++ b/resources/js/views/Detail.vue
@@ -46,6 +46,7 @@ export default {
                         '/refund'
                 )
                 .then((response) => {
+                    Nova.success('Charge Successfully Refunded!');
                     this.$refs.detail.getCharge();
                 });
 

--- a/resources/js/views/Detail.vue
+++ b/resources/js/views/Detail.vue
@@ -2,7 +2,19 @@
     <div>
         <heading class="mb-6">Charge Details</heading>
 
-        <charge-detail-card :charge-id="chargeId"></charge-detail-card>
+        <div class="flex flex-row-reverse mb-3">
+            <button
+                v-if="charge && !charge.refunded"
+                class="btn-primary px-4 py-2 rounded"
+                @click="refund(charge.id)"
+                :disabled="deleting"
+            >Refund</button>
+        </div>
+
+        <charge-detail-card
+            :charge-id="chargeId"
+            @charge-loaded="charge = $event"
+        />
     </div>
 </template>
 
@@ -11,9 +23,24 @@
 
     export default {
         props: ['chargeId'],
-
         components: {
             'charge-detail-card': ChargeDetailCard,
-        }
+        },
+        data() {
+            return {
+                charge: undefined,
+                deleting: false,
+            }
+        },
+        methods: {
+            refund(chargeId) {
+                this.deleting = !this.deleting;
+
+                // axios call here
+
+
+                this.deleting = !this.deleting;
+            },
+        },
     }
 </script>

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,4 +18,5 @@ use Tighten\NovaStripe\Http\StripeChargesController;
 
 Route::get('/stripe/charges', StripeChargesController::class . '@index');
 Route::get('/stripe/charges/{id}', StripeChargesController::class . '@show');
+Route::post('/stripe/charges/{id}/refund', StripeChargesController::class . '@refund');
 Route::get('/stripe/balance', StripeBalanceController::class . '@index');

--- a/src/Clients/StripeClient.php
+++ b/src/Clients/StripeClient.php
@@ -5,6 +5,7 @@ namespace Tighten\NovaStripe\Clients;
 use Exception;
 use Stripe\Balance;
 use Stripe\Charge;
+use Stripe\Refund;
 
 class StripeClient
 {
@@ -48,6 +49,24 @@ class StripeClient
     {
         try {
             return Balance::retrieve(['api_key' => $this->apiKey]);
+        } catch (Exception $e) {
+
+        }
+    }
+
+    public function refundCharge($chargeId)
+    {
+        try {
+            return Refund::create(['charge' => $chargeId], ['api_key' => $this->apiKey]);
+        } catch (Exception $e) {
+
+        }
+    }
+
+    public function createCharge(array $params)
+    {
+        try {
+            return Charge::create($params, ['api_key' => $this->apiKey]);
         } catch (Exception $e) {
 
         }

--- a/src/Http/StripeChargesController.php
+++ b/src/Http/StripeChargesController.php
@@ -24,6 +24,6 @@ class StripeChargesController extends Controller
 
     public function refund($id)
     {
-        return (new StripeClient)->refundCharge($id);
+        return response()->json((new StripeClient)->refundCharge($id));
     }
 }

--- a/src/Http/StripeChargesController.php
+++ b/src/Http/StripeChargesController.php
@@ -3,6 +3,7 @@
 namespace Tighten\NovaStripe\Http;
 
 use Illuminate\Routing\Controller;
+use Stripe\Charge;
 use Tighten\NovaStripe\Clients\StripeClient;
 
 class StripeChargesController extends Controller
@@ -19,5 +20,10 @@ class StripeChargesController extends Controller
     public function show($id)
     {
         return response()->json(['charge' => (new StripeClient)->getCharge($id)]);
+    }
+
+    public function refund($id)
+    {
+        return (new StripeClient)->refundCharge($id);
     }
 }


### PR DESCRIPTION
Adds a refund button to the charge detail screen.

Also in this PR: 
- configure Prettier
- update tests to use the NovaStripe gateway, rather than the Stripe SDK gateway.

**Refund Button**
<img width="1314" alt="Screen Shot 2021-07-20 at 5 07 17 PM" src="https://user-images.githubusercontent.com/4378273/126395634-6449786a-e419-4c26-ba4c-7ddd6845ed3f.png">


**After Refund**
<img width="1246" alt="Screen Shot 2021-07-20 at 5 07 23 PM" src="https://user-images.githubusercontent.com/4378273/126395689-470da625-0810-4e87-8ff4-e4aecb8bae06.png">
