### PR TITLE
Add back PHP 7.4 compatibility

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -36,6 +36,9 @@ jobs:
             laravel: 9.*
             testbench: 7.*
             phpunit: 9.*
+        exclude:
+          - php: 7.4
+            laravel: 9.*
     services:
       stripemock:
         image: stripe/stripe-mock:v0.141.0

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -13,9 +13,13 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        php: [ 8.0, 8.1 ]
+        php: [ 7.4, 8.0, 8.1 ]
         laravel: [ 8.*, 9.* ]
         include:
+          - php: 7.4
+            laravel: 8.*
+            testbench: 6.*
+            phpunit: 9.*
           - php: 8.0
             laravel: 8.*
             testbench: 6.*

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.0|^8.1",
+        "php": "^7.4|^8.0|^8.1",
         "stripe/stripe-php": ">=5.0"
     },
     "require-dev": {


### PR DESCRIPTION
Per a user request, adds back compatibility with PHP 7.4. 

Nova itself supports back to 7.3, but no plans to support that for now. 