### PR TITLE
Update .env.testing.example

### DIFF
--- a/.env.testing.example
+++ b/.env.testing.example
@@ -1,2 +1,2 @@
 STRIPE_TEST_SECRET=sk_test_123
-STRIPE_API_BASE="stripemock:12111"
+STRIPE_API_BASE="localhost:12111"


### PR DESCRIPTION
Fixes an incorrect value for the `STRIPE_API_BASE` value